### PR TITLE
Compatibility tweaks for case-insensitive filesystems & TDS installation (fixes #47)

### DIFF
--- a/TeX/elstob.sty
+++ b/TeX/elstob.sty
@@ -73,7 +73,7 @@
 
 % ALTERNATE STYLES
 
-\directlua{dofile("elstob.lua")
+\directlua{require("elstob")
 mkaltcommands()}
 
 % PROCESS OPTIONS

--- a/TeX/elstob.sty
+++ b/TeX/elstob.sty
@@ -73,7 +73,7 @@
 
 % ALTERNATE STYLES
 
-\directlua{dofile("Elstob.lua")
+\directlua{dofile("elstob.lua")
 mkaltcommands()}
 
 % PROCESS OPTIONS


### PR DESCRIPTION
Fixes 2 issues in `elstob.sty`:
- incompatibility with use on case-insensitive file systems e.g. the package won't work on basically any Linux or FreeBSD system (`Elstob` -> `elstob` in the `\directlua{}`);
- inability to use the package if installed into a TDS tree (`dofile` -> `require` so `kpathsea` search is triggered).

Fixes #47 .

TeX SE: https://tex.stackexchange.com/q/757333/